### PR TITLE
0.3.100

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ Coin Market is a simple library designed to make it easy get market or account i
 
 ## DEPRECATION NOTICE
 
-- Because of changes made in ShapeShift's organization, I've deprecated the CoinExchange module and will no longer available after 0.3.
-- The Ethereum module will be deprecated in 0.4 and replaced by a generic Web3 API to accommodate newer EVM-based networks.
-- Version 0.5 will be the **final** release.
+- The Ethereum module has been deprecated and will replaced by a generic Web3 API to accommodate newer EVM-based networks.
+- Version 0.4 will be the **final** release.
 
 ## Installation
 
@@ -23,9 +22,10 @@ coinmarket = "0.3"
 use coinmarket::web3::{Ethereum, EthNetworks};
 
 pub fn main() {
-    let network = Web3::new(Web3Provider::MainNet);
-    let balance = network.ether_balance("0x341A3A994A150962F3e82b195873B736dAEb4bB3")
-        .expect("Parsing error");
+    let network = Web3::new("api.etherscan.io");
+    let balance = network
+    .ether_balance("0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B")
+    .expect("Parsing error");
 
     println!("{}", balance);
 }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Coin Market is a simple library designed to make it easy get market or account i
 
 ```toml
 [dependencies]
-coinmarket = "0.2"
+coinmarket = "0.3"
 ```
 
 ## Examples
@@ -20,7 +20,7 @@ coinmarket = "0.2"
 ### EVM account balance
 
 ```rust
-use coinmarket::ethereum::{Ethereum, EthNetworks};
+use coinmarket::web3::{Ethereum, EthNetworks};
 
 pub fn main() {
     let network = Web3::new(Web3Provider::MainNet);

--- a/README.md
+++ b/README.md
@@ -16,13 +16,36 @@ coinmarket = "0.3"
 
 ## Examples
 
-### EVM account balance
+## New
+
+```env
+APIKEY=[key]
+```
 
 ```rust
-use coinmarket::web3::{Ethereum, EthNetworks};
+use coinmarket::web3::Web3;
 
 pub fn main() {
     let network = Web3::new("api.etherscan.io");
+    let balance = network
+    .ether_balance("0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B")
+    .expect("Parsing error");
+
+    println!("{}", balance);
+}
+```
+
+### Legacy
+
+```env
+ETHSCAN=[key]
+```
+
+```rust
+use coinmarket::ethereum::{Web3, Web3Provider};
+
+pub fn main() {
+    let network = Web3::new(Web3Provider::MainNet);
     let balance = network
     .ether_balance("0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B")
     .expect("Parsing error");

--- a/examples/web3.rs
+++ b/examples/web3.rs
@@ -1,11 +1,11 @@
 extern crate coinmarket;
 
-use coinmarket::ethereum::{Web3, Web3Provider};
+use coinmarket::web3::Web3;
 
 pub fn main() {
-    let address = "0x341A3A994A150962F3e82b195873B736dAEb4bB3";
+    let address = "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B";
     let err_msg = "Parsing error";
-    let network = Web3::new(Web3Provider::MainNet);
+    let network = Web3::new("api.etherscan.io");
     let balance = network.get_balance(address).expect(err_msg);
     let total_supply = network.get_total_supply().expect(err_msg);
     let last_price = network.get_last_price().expect(err_msg);

--- a/src/ethereum.rs
+++ b/src/ethereum.rs
@@ -21,7 +21,10 @@ pub enum Web3Provider {
     Kovan,
 }
 
-#[deprecated(since = "0.3.100", note = "This will be replaced by the web3 module.")]
+#[deprecated(
+    since = "0.3.100",
+    note = "Please use the Web3 module. This will removed in 0.4.100."
+)]
 pub struct Web3 {
     provider: Web3Provider,
 }

--- a/src/ethereum.rs
+++ b/src/ethereum.rs
@@ -21,6 +21,7 @@ pub enum Web3Provider {
     Kovan,
 }
 
+#[deprecated(since = "0.3.100", note = "This will be replaced by the web3 module.")]
 pub struct Web3 {
     provider: Web3Provider,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod ethereum;
 pub mod models;
+pub mod web3;

--- a/src/models.rs
+++ b/src/models.rs
@@ -8,23 +8,6 @@ pub struct ValidateAddress {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct MarketInfo {
-    pub rate: f64,
-    #[serde(rename(deserialize = "minerFee"))]
-    pub miner_fee: f64,
-    pub limit: f64,
-    pub minimum: f64,
-    #[serde(rename(deserialize = "maxLimit"))]
-    pub max_limit: f64,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct ExchangeLimit {
-    pub limit: f64,
-    pub minimum: f64,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
 pub struct Etherscan<T> {
     pub status: String,
     pub message: String,

--- a/src/web3.rs
+++ b/src/web3.rs
@@ -19,9 +19,9 @@ pub struct Web3 {
 }
 
 impl Web3 {
-    pub fn new(provider: String) -> Self {
+    pub fn new<S: Into<String>>(provider: S) -> Self {
         Web3 {
-            provider: format!("https://{}/api?module=", provider),
+            provider: format!("https://{}/api?module=", provider.into()),
         }
     }
 

--- a/src/web3.rs
+++ b/src/web3.rs
@@ -14,12 +14,15 @@ fn get_api_key() -> String {
 }
 
 pub struct Web3 {
+    /// Etherscan-based API address without HTTP included.
     provider: String,
 }
 
 impl Web3 {
     pub fn new(provider: String) -> Self {
-        Web3 { provider }
+        Web3 {
+            provider: format!("https://{}/api?module=", provider),
+        }
     }
 
     pub fn get_balance<S: Into<String>>(&self, address: S) -> Result<String, Error>
@@ -28,7 +31,7 @@ impl Web3 {
     {
         let request = format!(
             "{}account&action=balance&address={}&tag=latest{}",
-            self.get_network(self.provider),
+            self.provider,
             address.into(),
             get_api_key().as_str()
         );
@@ -41,7 +44,7 @@ impl Web3 {
     pub fn get_total_supply(&self) -> Result<String, Error> {
         let request = format!(
             "{}stats&action=ethsupply{}",
-            self.get_network(self.provider),
+            self.provider,
             get_api_key().as_str()
         );
         let mut response = reqwest::get(&request)?;
@@ -53,7 +56,7 @@ impl Web3 {
     pub fn get_last_price(&self) -> Result<EthPrice, Error> {
         let request = format!(
             "{}stats&action=ethprice{}",
-            self.get_network(self.provider),
+            self.provider,
             get_api_key().as_str()
         );
         let mut response = reqwest::get(&request)?;
@@ -72,7 +75,7 @@ impl Web3 {
     {
         let request = format!(
             "{}account&action=txlist&address={}&startblock={}&endblock={}&sort=asc{}",
-            self.get_network(self.provider),
+            self.provider,
             address.into(),
             start_block,
             end_block,


### PR DESCRIPTION
- Removed Exchange module
- Deprecated Etherum API for generic Web3 equivalent
- Web3 API supports any Etherscan-based API